### PR TITLE
Improved error handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,7 +90,13 @@ func findFilesInPaths(pathlist []string, callback func(os.FileInfo, string)) {
 			err := filepath.Walk(path, func(path string, f os.FileInfo, err error) error {
 				path, _ = filepath.Abs(path)
 
-				if f.IsDir() {
+				if err != nil {
+					log.Infof("Error %s for path %s", err, path)
+
+					return nil
+				}
+
+				if f == nil || f.IsDir() {
 					return nil
 				}
 


### PR DESCRIPTION
Prevents go-crond from crashing and shows a readable error message instead:

`time=2025-04-23T17:39:16+02:00 level=info msg=Error lstat /etc/cron.d/ftth-cron: permission denied for path /etc/cron.d/ftth-cron`